### PR TITLE
Pydantic upgraded to >= 1.6.2.

### DIFF
--- a/runtool/setup.py
+++ b/runtool/setup.py
@@ -20,6 +20,10 @@ setup(
     packages=find_packages("./runtool"),
     description="Gluonts run tool package",
     include_package_data=True,
-    install_requires=["PyYAML", "pydantic", "toolz"],
+    install_requires=[
+        "PyYAML",
+        "pydantic>=1.6.2",
+        "toolz",
+    ],
     entry_points={},
 )

--- a/sagetest/examples/example_test.py
+++ b/sagetest/examples/example_test.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from sagetest.jobs import Jobs
+from sagetest import SageTest, Filter
+import boto3
+
+# create a SageTest sesssion
+sagetest = SageTest(
+    locals(),
+    session=boto3.Session(),
+)
+
+# Create a pytest fixture containing SageMaker training jobs
+sagetest.fixture(
+    fixture_name="reference_job",
+    filters=Filter(names=["a training job name"]),
+)
+
+# Use fixture
+def test_sagetest_fixture(reference_job: Jobs):
+    print(reference_job.metrics)
+    assert 0
+
+
+# create a pytest.mark.parametrize populated with SageMaker training jobs.
+@sagetest.parametrize(
+    "jobs",
+    [
+        Filter(names=["some job name"]),
+        Filter(names=["another job name"]),
+    ],
+)
+def test_some_jobs(jobs: Jobs):
+    print("jobs", jobs.metrics)
+    assert 0

--- a/sagetest/sagetest/__init__.py
+++ b/sagetest/sagetest/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from .sagetest import SageTest
+from .search import Filter, query

--- a/sagetest/sagetest/cli.py
+++ b/sagetest/sagetest/cli.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from pathlib import Path
+
+import click
+
+from .sagetest import run
+
+
+@click.command()
+@click.argument("path")
+def cli(path: str):
+    path = Path(path).resolve()
+    run(path)
+
+
+if __name__ == "__main__":
+    cli()

--- a/sagetest/sagetest/jobs.py
+++ b/sagetest/sagetest/jobs.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Any, List, Union
+
+import pandas as pd
+import yaml
+from pydantic.main import BaseModel
+
+
+class Job(BaseModel):
+    metrics: dict
+    training_time: int
+    hyperparameters: dict
+    tags: dict
+
+    def __getitem__(self, key: Any) -> Any:
+        return self.json[key]
+
+    def __repr__(self) -> str:
+        return yaml.dump(self.json)
+
+    @classmethod
+    def from_json(cls, json: dict) -> "Job":
+        return cls(
+            training_time=json.get("TrainingTimeInSeconds", None),
+            hyperparameters=json.get("HyperParameters", {}),
+            tags={
+                key: value
+                for tag in json.get("Tags", {})
+                for key, value in tag.items()
+            },
+            metrics={
+                metric["MetricName"]: metric["Value"]
+                for metric in json.get("FinalMetricDataList", [])
+            },
+        )
+
+
+class Jobs:
+    def __init__(self, job_list: List[Job] = []) -> None:
+        self.data = job_list
+        self.update_metrics_dataframe()
+
+    def pop(self, index) -> Job:
+        popped = self.data.pop(index)
+        self.update_metrics_dataframe()
+        return popped
+
+    def update_metrics_dataframe(self) -> None:
+        self.metrics = pd.DataFrame((job.metrics for job in self.data))
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, key) -> Union[Job, "Jobs"]:
+        if isinstance(key, slice):
+            return Jobs(self.data[key])
+        return self.data[key]
+
+    @classmethod
+    def from_json_list(cls, sm_jsons: List[dict]) -> "Jobs":
+        return cls(list(map(Job.from_json, sm_jsons)))

--- a/sagetest/sagetest/plugin/conftest.py
+++ b/sagetest/sagetest/plugin/conftest.py
@@ -20,12 +20,14 @@ def pytest_addoption(parser):
     parser.addoption(
         "--sagetest_fixtures",
         action="store",
-        default='{"my_fixture": {"names": ["71626642--2021-05-03--05-05-50-528194--37886482-0"]}}',
+        default="{}",
         help="""Dictionary which will be added to the `cli_fixtures` fixture when tests are run. 
-        The values of the dictionary will be converted to `sagetest.Jobs` objects.
+        The values of the dictionary will be passed to a Filters object as kwargs and must thus. 
+        These filters are then used to query SageMaker.
+
         Example:
 
-        {\"my_fixture\": {\"names\": [\"71626642--2021-05-03--05-05-50-528194--37886482-0\"]}}
+        {\"my_fixture\": {\"names\": [\"my-training-job-name\"]}}
         
         Is accessable in the test file as:
 

--- a/sagetest/sagetest/plugin/conftest.py
+++ b/sagetest/sagetest/plugin/conftest.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Pytest plugin which adds a commandline option to pytest."""
+
+
+def pytest_addoption(parser):
+    """Add --fixtures as option to pytest cli"""
+
+    parser.addoption(
+        "--sagetest_fixtures",
+        action="store",
+        default='{"my_fixture": {"names": ["71626642--2021-05-03--05-05-50-528194--37886482-0"]}}',
+        help="""Dictionary which will be added to the `cli_fixtures` fixture when tests are run. 
+        The values of the dictionary will be converted to `sagetest.Jobs` objects.
+        Example:
+
+        {\"my_fixture\": {\"names\": [\"71626642--2021-05-03--05-05-50-528194--37886482-0\"]}}
+        
+        Is accessable in the test file as:
+
+        def my_test(cli_fixtures):
+            jobs = cli_fixtures['my_fixture']
+        """,
+    )

--- a/sagetest/sagetest/sagetest.py
+++ b/sagetest/sagetest/sagetest.py
@@ -1,0 +1,121 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import json
+
+from _pytest.mark import param
+from sagetest.jobs import Jobs
+from typing import Any, Dict, Iterable, List, Tuple, Union
+
+import boto3
+import pytest
+
+from .search import Filter, query
+
+
+class SageTest:
+    def __init__(self, _locals, session=boto3.Session()) -> None:
+        self.locals = _locals
+        self.session = session
+        self.setup_sagetest_fixture()
+        self.setup_commandline_fixtures()
+
+    def setup_sagetest_fixture(self):
+        """Make `self` available as pytest fixture `sagetest_instance`."""
+
+        def sagetest_instance_fixture():
+            yield self
+
+        self.locals["sagetest_instance"] = pytest.fixture(
+            name="sagetest_instance",
+            fixture_function=sagetest_instance_fixture,
+            scope="session",
+            autouse=True,
+        )
+
+    def setup_commandline_fixtures(self):
+        """Setup fixture from CLI arguments."""
+
+        def fixture(pytestconfig) -> Dict[str, Jobs]:
+            """Query SageMaker using args passed from --sagetest_fixtures."""
+            filters = json.loads(pytestconfig.getoption("--sagetest_fixtures"))
+            yield {
+                fixture_name: self.search(Filter(**filterkwargs))
+                for fixture_name, filterkwargs in filters.items()
+            }
+
+        self.locals["cli_fixtures"] = pytest.fixture(
+            name="cli_fixtures",
+            fixture_function=fixture,
+            scope="session",
+            autouse=True,
+        )
+
+    def search(
+        self, filters: Union[List[Filter], Filter]
+    ) -> Union[List[Jobs], Jobs]:
+        """Query sagemaker with each filter."""
+        if isinstance(filters, Filter):
+            return query(filters, self.session)
+        return [query(_filter, self.session) for _filter in filters]
+
+    def fixture(
+        self,
+        fixture_name: str,
+        filters: Union[List[Filter], Filter],
+        scope: str = "session",
+    ) -> List[Jobs]:
+        """Create a pytest fixture where filters are transformed to `sagetest.Jobs`."""
+
+        def fixture_function():
+            yield self.search(filters)
+
+        self.locals[fixture_name] = pytest.fixture(
+            name=fixture_name, fixture_function=fixture_function, scope=scope
+        )
+
+    def parametrize(
+        self,
+        argnames: Iterable[str],
+        argvalues: Iterable[Tuple[Filter, Any]],
+    ):
+        """
+        Create a `pytest.parametrize` decorator populated with `Jobs`.
+
+        Any `Filter` objects in the `argvalues` are used to query SageMaker
+        for training jobs. The results will be passed to `pytest.parametrize`
+        as `sagetest.Jobs` objects inplace of the filters used.
+        """
+
+        def update_parameters(
+            parameters: Union[Tuple[Filter, ...], Filter, Any]
+        ) -> Union[Tuple[Jobs, ...], Jobs, Any]:
+            if isinstance(parameters, Filter):
+                return self.search(parameters)
+
+            if isinstance(parameters, Tuple):
+                updated_params = tuple(
+                    map(
+                        lambda param: self.search(param)
+                        if isinstance(param, Filter)
+                        else param,
+                        parameters,
+                    )
+                )
+                return updated_params
+            return parameters
+
+        return pytest.mark.parametrize(
+            argnames=argnames,
+            argvalues=list(map(update_parameters, argvalues)),
+        )

--- a/sagetest/sagetest/search.py
+++ b/sagetest/sagetest/search.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from .jobs import Jobs
+
+
+class Filter(BaseModel):
+    expression: str = None
+    algorithm: str = None
+    hyperparameters: dict = None
+    dataset: str = None
+    tags: dict = None
+    start_time: datetime = None
+    end_time: datetime = None
+    names: list = None
+    status: list = None
+    search_filters: list = None
+    max_results: int = 100
+
+    def convert_to_sagemaker(self):
+        sm_filters = []
+
+        def add_filter(name, value, operator="Equals"):
+            sm_filters.append(
+                {
+                    "Name": name,
+                    "Operator": operator,
+                    "Value": value,
+                }
+            )
+
+        if self.tags:
+            for key, val in self.tags.items():
+                add_filter(f"Tags.{key}", val)
+
+        if self.hyperparameters:
+            for key, val in self.hyperparameters.items():
+                add_filter(f"HyperParameters.{key}", str(val))
+
+        if self.algorithm:
+            add_filter(
+                "AlgorithmSpecification.AlgorithmName"
+                if self.algorithm.startswith("arn:aws")
+                else "AlgorithmSpecification.TrainingImage",
+                self.algorithm,
+            )
+
+        if self.dataset:
+            add_filter(
+                "InputDataConfig.DataSource.S3DataSource.S3Uri",
+                self.dataset,
+            )
+
+        if self.names:
+            add_filter("TrainingJobName", ",".join(self.names), operator="In")
+
+        if self.status:
+            add_filter(
+                "TrainingJobStatus", ",".join(self.status), operator="In"
+            )
+
+        if self.search_filters:
+            sm_filters += self.search_filters
+
+        return sm_filters
+
+
+def query(job_filter: Filter, session):
+    filters = job_filter.convert_to_sagemaker()
+    if not filters:
+        raise ValueError("Empty filters in query")
+
+    print("querying sagemaker with these filters:\n", filters)
+
+    sagemaker = session.client(service_name="sagemaker")
+    paginator = sagemaker.get_paginator("search")
+
+    pages = paginator.paginate(
+        Resource="TrainingJob",
+        SearchExpression={"Filters": filters},
+        PaginationConfig={
+            "PageSize": min(job_filter.max_results, 100),
+            "MaxItems": job_filter.max_results,
+        },
+        SortBy="CreationTime",
+    )
+
+    pages = list(pages)
+
+    # Iterate over the fetched training jobs and only save those within
+    # within the desired timeframe
+    all_jobs = [
+        job["TrainingJob"] for page in pages for job in page["Results"]
+    ]
+
+    return Jobs.from_json_list(all_jobs)

--- a/sagetest/setup.py
+++ b/sagetest/setup.py
@@ -1,0 +1,36 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from setuptools import find_packages, setup
+
+setup(
+    name="sagetest",
+    version="0.1.0",
+    author="Amazon",
+    packages=find_packages("./sagetest"),
+    description="Sagetest package for applying tests to sagemaker training jobs",
+    include_package_data=True,
+    install_requires=[
+        "PyYAML",
+        "pydantic",
+        "toolz",
+        "pytest",
+        "Click",
+        "pyyaml",
+        "pandas",
+    ],
+    entry_points={
+        "console_scripts": ["sagetest = sagetest.cli:cli"],
+        "pytest11": ["name_of_plugin = sagetest.plugin.conftest"],
+    },
+)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Pydantic >= 1.6.2 patches vulnerability when `inf` was passed to datetime objects.
  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
