### PR TITLE
Updated pydantic version to >=1.6.2.

### DIFF
--- a/runtool/setup.py
+++ b/runtool/setup.py
@@ -20,6 +20,10 @@ setup(
     packages=find_packages("./runtool"),
     description="Gluonts run tool package",
     include_package_data=True,
-    install_requires=["PyYAML", "pydantic", "toolz"],
+    install_requires=[
+        "PyYAML",
+        "pydantic>=1.6.2",
+        "toolz",
+    ],
     entry_points={},
 )


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Pydantic >= 1.6.2 patches vulnerability when inf was passed to datetime objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.